### PR TITLE
Fix status text formatation in panel

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -47,9 +47,9 @@ class NordVPN {
         const data = (GLib.spawn_command_line_sync(this._commands.status)[1]);
         let fullStatus;
         if (data instanceof Uint8Array) {
-            fullStatus = imports.byteArray.toString(data);
+            fullStatus = imports.byteArray.toString(data).trim();
         } else {
-            fullStatus = data.toString();
+            fullStatus = data.toString().trim();
         }
         const result = fullStatus.split('\n');
         const statusLine = result.find((line) => line.includes("Status:"));
@@ -162,7 +162,7 @@ class VPNStatusIndicator extends PanelMenu.SystemIndicator {
     _update(vpnStatus) {
         // Update the panel button
         this._indicator.visible = vpnStatus.connected;
-        this._item.label.text = `NordVPN (${vpnStatus.status})`;
+        this._item.label.text = `NordVPN ${vpnStatus.status}`;
 
         if (vpnStatus.connected) {
             if (!this._disconnectAction)


### PR DESCRIPTION
Hi. The extension works well, but I thought a few small enhancements would even make it work better. Here is my commit message that tries to explain the changes in detail:

The status text in panel had an additional newline '\n' at the end, leaving an
additional empty space and making it somewhat ugly. Using trim(), the newline
is now removed, and the status text looks a little better.

Also the parentheses in menu title text is removed. Now instead of
'NordVPN (Connected)', it now shows up like 'NordVPN Connected).